### PR TITLE
updating go version to available version in pcf

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - env:
-    GOVERSION: go1.9
+    GOVERSION: go1.10
     GOPACKAGENAME: github.com/cloudfoundry-samples/logging-route-service


### PR DESCRIPTION
version 1.9 of go is no longer available in Pivotal Cloud Foundry. Bumping the version.